### PR TITLE
Add support for Unknown state

### DIFF
--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -173,6 +173,10 @@ subcommands:
                 short: c
                 help: "print only critical states"
                 takes_value: false
+            - Unknown:
+                short: u
+                help: "print only unknown states"
+                takes_value: false
             - OK:
                 short: o
                 help: "print only ok states"

--- a/src/bin/icingacli.rs
+++ b/src/bin/icingacli.rs
@@ -141,7 +141,7 @@ fn main() {
         Some("problems") => {
             let matches = matches.subcommand_matches("problems").unwrap();
             if matches.args.is_empty() {
-                api::icinga_problems(conf.clone(), "Critical&service.state==ServiceWarning")
+                api::icinga_problems(conf.clone(), "Critical%7c%7cservice.state==ServiceWarning%7c%7cservice.state==ServiceUnknown")
             } else {
                 for state in &matches.args {
                     api::icinga_problems(conf.clone(), state.0)


### PR DESCRIPTION
This PR adds support for the unknown state and corrects the default logic when running `icingacli problems`.
